### PR TITLE
Inherit parameter array for gem style

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ $ bundle exec rubocop
 
 This gem includes rubocop, and it's not necessary to separately include rubocop directly in your application's dependencies.
 
+## Overriding Styles
+
+Note that if you add in a local style exception in your own application after inheriting from gnar-style, that will completely override gnar-style's defaults. This is particularly important if you're not looking to modify the style at all, but instead are hoping to add to, for example, the list of files excluded.
+
+Consider the following:
+```yaml
+# In gnar-style/default.yml
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+```
+
+```yaml
+# In your app's .rubocop.yml
+inherit_gem:
+  gnar-style:
+    - default.yml
+
+Metrics/BlockLength:
+  Exclude:
+    - specific_file.rb
+```
+
+In this example, all files in the spec directory will no longer be excluded from the `Metrics/BlockLength` cop. The excluded array is overridden, and not inherited. This is discussed in [this rubocop issue](https://github.com/bbatsov/rubocop/issues/3208), though the suggestion to have a `super` keyword does not seem to have been implemented.
+
+If you want to add to the list, you'll instead need to add in the prior array elements into your application's `.rubocop.yml` by referencing the initial list from gnar-style.
+
 ## Different Styles
 
 gnar-style provides defaults for three different scenarios. You can specify which configuration to use in your `rubocop.yml`. See the [Usage](#usage) section for details.

--- a/default_gem.yml
+++ b/default_gem.yml
@@ -1,5 +1,9 @@
 inherit_from: default.yml
 
+Layout/ExtraSpacing:
+  Exclude:
+    - '*.gemspec'
+
 Layout/SpaceAroundOperators:
   Exclude:
     - '*.gemspec'
@@ -7,7 +11,4 @@ Layout/SpaceAroundOperators:
 Metrics/BlockLength:
   Exclude:
     - '*.gemspec'
-
-Style/ExtraSpacing:
-  Exclude:
-    - '*.gemspec'
+    - 'spec/**/*'


### PR DESCRIPTION
This uses the default array values to inherit the Metric/BlockLength
exclusion list from the default and use it in the default-gem
specification. This also includes instructions on how to add to the list
with a local style exception.