### PR TITLE
Remove allowed push hosts

### DIFF
--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -14,15 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/TheGnarCo/gnar-style"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
This change modifies the gemspec to allow the gem to be pushed to any
gem server. As this is intended to be shared on rubygems, this
protection is unnecessary.