### PR TITLE
Enforce trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Current release (in development)
 
+* Enforce trailing commas for multi-line literals and method calls. [#10](https://github.com/TheGnarCo/gnar-style/pull/10)
+  *Zach Fletcher*
+
 ## 0.2.0
 
 * Move rubocop template files into `rubocop/` directory rather than the ambiguous `gnar_style/` directory. [#4](https://github.com/TheGnarCo/gnar-style/pull/4)

--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "gnar/style/version"

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -13,6 +13,12 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
 Style/SymbolArray:
   EnforcedStyle: brackets
 


### PR DESCRIPTION
Enforce trailing comma in literals and method calls. For example:

```ruby
# bad
x = [
  1,
  2
]

# bad
foo(
  1,
  2
)

# good
x = [
  1,
  2,
]

# good
foo(
  1,
  2,
)
```

Some benefits:

* reduces diff noise
* makes `git blame` work better
* makes it easier to copy, paste, or reorganize code
* is more regular syntax (the last line doesn't have a different ending than all the other lines)