### PR TITLE
Update code of conduct contact info

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at TODO: Write your email address. All
+reported by contacting the project team at conduct@gnar.dog. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
This provides an email address for members of the community to reach
out to for questions regarding the code of conduct or to report
potential violations.