### PR TITLE
Separate Trailing Comma Array and Hash Literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Current release (in development)
 
+* Update trailing comma literal cops for new rubocop version. [#17](https://github.com/TheGnarCo/gnar-style/pull/17)
+  [Kevin Murphy](https://github.com/kevin-j-m)
+
 ## 0.3.0 - 2017-11-03
 
 * Enforce trailing commas for multi-line literals and method calls. [#10](https://github.com/TheGnarCo/gnar-style/pull/10)

--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "gnar/style/version"
 
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.49"
+  spec.add_dependency "rubocop", "~> 0.53"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.14"

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -16,7 +16,10 @@ Style/Documentation:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/SymbolArray:


### PR DESCRIPTION
Rubocop 0.53.0 created two new cops for controlling trailing comma style
preferences for arrays and hashes which may be found here:
https://github.com/bbatsov/rubocop/pull/5307.

This removes the `Style/TrailingCommaInLiteral` cop in favor of these
more granular cops.

As a result of this change, gnar-style needs to be updated to use the
new cops and remove the use of the old one. This updates to use the new
cops and updates the gemspec to reflect that this now requires 0.53 of
rubocop in this version to adhere to the available cops.