### PR TITLE
Updates to rubocop_rails linters

### DIFF
--- a/rubocop/rubocop_rails.yml
+++ b/rubocop/rubocop_rails.yml
@@ -3,6 +3,7 @@ inherit_from: rubocop.yml
 AllCops:
   Exclude:
     - db/schema.rb
+    - 'bin/**/*'
     - 'vendor/**/*'
 
 Rails:
@@ -11,3 +12,9 @@ Rails:
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'
+
+Style/BlockComments:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false


### PR DESCRIPTION
- Exclude the `bin` directory.
- Disable `Style/BlockComments`: I see no reason to not allow block comments, and they get used in third-party documentation (spec_helper).
- Disable `Style/StringLiterals`: Don't enforce single- or double-quotes. Our current implementation is to require double everywhere, but single is the [default](https://github.com/bbatsov/rubocop/blob/master/manual/cops_style.md#stylestringliterals). I prefer double but do not feel so strongly that I believe we should change all existing code.