### PR TITLE
Updates to rubocop_rails / rubocop linters

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -41,3 +41,6 @@ Metrics/BlockLength:
 Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*'
+
+Style/BlockComments:
+  Enabled: false

--- a/rubocop/rubocop_rails.yml
+++ b/rubocop/rubocop_rails.yml
@@ -3,11 +3,34 @@ inherit_from: rubocop.yml
 AllCops:
   Exclude:
     - db/schema.rb
+    - 'bin/**/*'
+    - 'config/**/*'
     - 'vendor/**/*'
 
 Rails:
   Enabled: true
 
+Metrics/BlockLength:
+  Exclude:
+    - 'db/seeds.rb'
+    - 'spec/**/*'
+
+Metrics/LineLength:
+  Exclude:
+    - 'db/seeds.rb'
+
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'db/seeds.rb'
+    - 'spec/**/*'
+
+Style/StringLiterals:
+  Exclude:
+    - 'config.ru'
+    - 'Gemfile'
+    - 'Rakefile'
+    - 'spec/rails_helper.rb'


### PR DESCRIPTION
- Exclude the `bin` and `config` directories.
- Disable `Style/BlockComments`: I see no reason to not allow block comments, and they get used in third-party documentation (spec_helper).
- Ignore `seeds.rb` for block length, line length, and module length.
- Ignore single/double quotes in generated files (Gemfile, Rakefile, etc)