### PR TITLE
Assign variables inside conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Current release (in development)
 
+* Update conditional assignment preferred style. [#20](https://github.com/TheGnarCo/gnar-style/pull/20)
+  [Kevin Murphy](https://github.com/kevin-j-m)
+
 ## 0.4.0 - 2018-03-05
 
 * Update trailing comma literal cops for new rubocop version. [#17](https://github.com/TheGnarCo/gnar-style/pull/17)

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -7,6 +7,9 @@ Metrics/LineLength:
   Max: 100
   Severity: refactor
 
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_inside_condition
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 


### PR DESCRIPTION
This enforces the style of assigning variables inside of a conditional,
rather than using the return value of the conditional to assign the
variable.

```
bar = if foo
        1
      else
        2
      end

if foo
  bar = 1
else
  bar = 2
end
```