### PR TITLE
Empty methods should be expanded, not compact

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -44,3 +44,6 @@ Metrics/BlockLength:
 Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*'
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded


### PR DESCRIPTION
```ruby
# good
def show
end

# bad
def show; end
```