### PR TITLE
Optionally allow leading underscores when memoizing

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -44,3 +44,6 @@ Metrics/BlockLength:
 Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*'
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional


### PR DESCRIPTION
This commit:

* Allows users to prefix memoized variable names with an underscore or not.

Why?

* The leading underscore can be helpful to signal to the engineer that the instance variable should not be called directly.

Example:

```ruby
def api_response
  @_api_response ||= ApiClient.get(API_ENDPOINT)
end
```