### PR TITLE
Do not check for quote style anymore

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,8 +1,3 @@
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-  Exclude:
-    - 'Gemfile'
-
 Metrics/LineLength:
   Max: 100
   Severity: refactor


### PR DESCRIPTION
Everyone has an opinion on quote style.
EVERYONE has an opinion on quote style.
No one's opinion is the same. So we have gnar-style telling us to use double
quotes. And client projects telling us to use single quotes. And other
projects telling us to use double again.

This is very immaterial. They're all strings. The objects are 100%
interchangeable with each other. They both have specification requirements
that do not allow them in certain circumstances (single can't interpolate,
double need escaping more, and so on). There is no one true way. Consistency
doesn't buy us anything here.

Having CI break because of this is really quite frustrating because of how
trivial the issue is. Sure I can run `rubocop --fix` but what if I never had
to?