### PR TITLE
Exclude a few more directories in Rails

### DIFF
--- a/rubocop/rubocop_rails.yml
+++ b/rubocop/rubocop_rails.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - db/schema.rb
     - 'bin/**/*'
+    - 'node_modules/**/*'
     - 'vendor/**/*'
 
 Rails:

--- a/rubocop/rubocop_rails.yml
+++ b/rubocop/rubocop_rails.yml
@@ -3,6 +3,7 @@ inherit_from: rubocop.yml
 AllCops:
   Exclude:
     - db/schema.rb
+    - 'bin/**/*'
     - 'vendor/**/*'
 
 Rails:


### PR DESCRIPTION
I recently used the Rails RuboCop configuration for a new project. It was great overall, but I ended up having to add two more directories to the `Exclude` section of `rubocop_rails.yml`:

* `bin/`: which contains some automatically generated files that can't be automatically fixed to use Gnar Style.
* `node_modules/`: which, when using Webpacker, contains the `node-sass` package by default. This package has a Ruby file (`extconf.rb`) that RuboCop complains about. There are probably other npm packages that contain Ruby files as well.

I've included some more details in the commit messages themselves. Let me know what you think about the changes.