### PR TITLE
Exclude keyword args from parameter list count

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -47,3 +47,6 @@ Metrics/ModuleLength:
 
 Style/EmptyMethod:
   EnforcedStyle: expanded
+
+Metrics/ParameterLists:
+  CountKeywordArgs: false


### PR DESCRIPTION
```rb
# bad
def foo(param1, param2, param3, param4, param5, param6)
end

# fine
def foo(param1:, param2:, param3:, param4:, param5:, param6:)
end
```
[documentation](https://rubocop.readthedocs.io/en/latest/cops_metrics/#metricsparameterlists)