### PR TITLE
Enforce consistent indentation for arrays

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,6 +1,9 @@
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Layout/IndentArray:
+  EnforcedStyle: consistent
+
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 


### PR DESCRIPTION
```rb
# bad
in_a_method_call([
                  :its_like_this
                 ])

# good
in_a_method_call([
  :no_difference
])
```

[documentation](https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutindentarray)