### PR TITLE
Turn off enforcement of not-null db validations requiring default values

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -16,6 +16,9 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*'
 
+Rails/NotNullColumn:
+  Enabled: false
+
 Style/ConditionalAssignment:
   EnforcedStyle: assign_inside_condition
   IncludeTernaryExpressions: false


### PR DESCRIPTION
```rb
# bad
  def change
    add_column :table_name, :column_name, :string, null: false, default: "foo"
  end

# good
  def change
    add_column :table_name, :column_name, :string, null: false
  end
```

[(not so great) documentation](https://rubocop.readthedocs.io/en/latest/cops_rails/#railsnotnullcolumn)

I don't know if people agree with this but I think I'd rather a save fail if a value is null rather than succeed by saving some arbitrary default value.