### PR TITLE
Allow conditional assignment in ternary expressions

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -9,6 +9,7 @@ Metrics/LineLength:
 
 Style/ConditionalAssignment:
   EnforcedStyle: assign_inside_condition
+  IncludeTernaryExpressions: false
 
 Style/FrozenStringLiteralComment:
   Enabled: false


### PR DESCRIPTION
```rb
# bad
  bar? ? foo = 1 : foo = 2

# fine
  foo = bar? ? 1 : 2
```

[documentation](https://rubocop.readthedocs.io/en/latest/cops_style/#styleconditionalassignment)

Our current enforced style is `assign_inside_condition`, which requires the following:

```rb
if bar
  foo = 1
else
  foo = 2
end
```

that's fine, but following that same structure is (in my opinion) harder to follow in a ternary expression.