### PR TITLE
Alphabetize cop rules

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,21 +1,44 @@
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Metrics/BlockLength:
   Exclude:
-    - 'Gemfile'
+    - 'spec/**/*'
 
 Metrics/LineLength:
   Max: 100
   Severity: refactor
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*'
+
 Style/ConditionalAssignment:
   EnforcedStyle: assign_inside_condition
   IncludeTernaryExpressions: false
 
+Style/Documentation:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Style/Documentation:
+Style/ParenthesesAroundCondition:
   Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  Exclude:
+    - 'Gemfile'
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
@@ -25,26 +48,3 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
-
-Style/SymbolArray:
-  EnforcedStyle: brackets
-
-Style/ParenthesesAroundCondition:
-  Enabled: false
-
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-
-Layout/AlignParameters:
-  EnforcedStyle: with_fixed_indentation
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*'
-
-Metrics/ModuleLength:
-  Exclude:
-    - 'spec/**/*'
-
-Style/EmptyMethod:
-  EnforcedStyle: expanded


### PR DESCRIPTION
This modifies the organization of the different style variances against
rubocop defaults such that they should be alphabetized. This should help
with discoverability while, as far as I'm aware, not resulting in any
functional difference or impacting readability.

I generally don't prefer alphabetization for alphabetization's sake, but I think most related cops will have similar names such that they'll still be clumped together. I can readily be talked out of this is people see that this is eliminating a grouping that previously we benefited from.