### PR TITLE
Remove Style/IfUnlessModifier cop

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -29,6 +29,9 @@ Style/EmptyMethod:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/ParenthesesAroundCondition:
   Enabled: false
 


### PR DESCRIPTION
By default, rubocop will look for instances where an if test can be
rewritten to have a trailing conditional (or a modifier, as it calls
it). So, given the following code:

```
if true
  puts "hello!"
end
```

By default, rubocop will propose changing that to:

```
puts "hello!" if true
```

That raises readability concerns for multiple team members here, where
the condition at the end of the line may be passed over if glancing
quickly, and the explicit `if`, though more lines of code, can be a more
explicit and helpful form of the same expression.

As a result, this proposes turning that cop off so that it'll be up to
the best judgement of the developer for how to write their if
conditions. As far as I'm aware, there is no nuance or options available
with this [cop](https://rubocop.readthedocs.io/en/latest/cops_style/#styleifunlessmodifier), which leaves us with an on or off decision.