### PR TITLE
Remove rubygems twitter from release process

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -5,4 +5,3 @@
 * Create a commit, including the version number in the commit message: `git add
   --all && git commit -m "Version x.y.z"`.
 * Push the release to RubyGems: `rake release`.
-* Check the RubyGems [twitter account](https://twitter.com/rubygems) to publicize the release.


### PR DESCRIPTION
The account hasn't tweeted since March 2nd. It's unclear if this account
will still be used to promote gem updates.