### PR TITLE
Rename IndentArray cop

### DIFF
--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.53"
+  spec.add_dependency "rubocop", "~> 0.68"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.14"

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,7 +1,7 @@
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
In rubocop [0.68.0](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0680-2019-04-29),
the `IndentArray` cop was renamed to `IndentFirstArrayElement`. This
change supports that name change by modifying our style principle for
this cop to be named appropriately.

This also updates the rubocop version that this is dependent on, as that
name change first appears in 0.68.0, so for rubocop to understand what
to do with that cop, we must have that version.