### PR TITLE
Align Method Arguments With Fixed Indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Current release (in development)
 
+* Align method arguments with fixed indentation. [#38](https://github.com/TheGnarCo/gnar-style/pull/38)
+
+  [Kevin Murphy](https://github.com/kevin-j-m)
+
 ## 0.6.1 - 2019-04-30
 
 * Rename IndentArray cop. [#37](https://github.com/TheGnarCo/gnar-style/pull/37)

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,3 +1,6 @@
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 


### PR DESCRIPTION
Added in rubocop 0.68, this [cop](https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutalignarguments) is concerned with arguments of a
multi-line method. Using `with_fixed_indentation` is consistent with our
`AlignParameters` cop and seems consistent with other code we've
written.

```ruby
# good
foo :bar,
  :baz

# bad
foo :bar,
    :baz
```