### PR TITLE
Include rubocop performance cops

### DIFF
--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.72"
+  spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails", "~> 2.2.0"
   spec.add_dependency "thor"
 

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 Layout/AlignArguments:
   EnforcedStyle: with_fixed_indentation
 


### PR DESCRIPTION
Performance cops have been removed from RuboCop 0.68. They have been
extracted to a separate gem, [rubocop-performance](https://github.com/rubocop-hq/rubocop-performance).

This includes that gem as a dependency of this project, and updates the
rubocop configuration file to require those cops. This should return the
cops that were previously checked in rubocop < 0.68.