### PR TITLE
Remove guard clause cop

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -38,6 +38,9 @@ Style/EmptyMethod:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Style/IfUnlessModifier:
   Enabled: false
 


### PR DESCRIPTION
I don't feel we should recommend guard clauses over `if` statements
universally. There are very often cases in which I find it more logical
to read an `if` statement.