### PR TITLE
Require rubocop-rails

### DIFF
--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.68"
+  spec.add_dependency "rubocop", "~> 0.72"
+  spec.add_dependency "rubocop-rails", "~> 2.2.0"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler", "~> 1.14"

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -22,9 +22,6 @@ Metrics/ModuleLength:
   Exclude:
     - 'spec/**/*'
 
-Rails/NotNullColumn:
-  Enabled: false
-
 Style/ConditionalAssignment:
   EnforcedStyle: assign_inside_condition
   IncludeTernaryExpressions: false

--- a/rubocop/rubocop_rails.yml
+++ b/rubocop/rubocop_rails.yml
@@ -1,5 +1,7 @@
 inherit_from: rubocop.yml
 
+require: rubocop-rails
+
 AllCops:
   Exclude:
     - db/schema.rb
@@ -7,9 +9,9 @@ AllCops:
     - 'node_modules/**/*'
     - 'vendor/**/*'
 
-Rails:
-  Enabled: true
-
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'
+
+Rails/NotNullColumn:
+  Enabled: false


### PR DESCRIPTION
In RuboCop [0.72](https://github.com/rubocop-hq/rubocop/releases/tag/v0.72.0), Rails cops were removed and put in a separate Gem called [rubocop-rails](https://github.com/rubocop-hq/rubocop-rails). Since Gnar Style uses some Rails cops, this means that it doesn't work correctly with RuboCop >= 0.72.

To see the issue, you can clone the `gnar-style` repo (or update `rubocop` to `0.72` in `Gemfile.lock`), run `bundle install`, then `bundle exec rubocop`. It will show the following warnings:

```
Warning: unrecognized cop Rails/NotNullColumn found in rubocop/rubocop.yml
Warning: unrecognized cop Rails/NotNullColumn found in rubocop/rubocop_gem.yml
Warning: unrecognized cop Rails/NotNullColumn found in .rubocop.yml
Inspecting 11 files
...........

11 files inspected, no offenses detected
```