### PR TITLE
Fix errors due to renamed cops

### DIFF
--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.72"
+  spec.add_dependency "rubocop", "~> 0.77"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails", "~> 2.2.0"
   spec.add_dependency "thor"

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,12 +1,12 @@
 require: rubocop-performance
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
When running rubocop using gnar-style on a new application I got the
following errors:

```
Error: The `Layout/AlignArguments` cop has been renamed to
`Layout/ArgumentAlignment`.
(obsolete configuration found in
/Users/michaelstone/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/gnar-style-0.8.0/rubocop/rubocop.yml,
please update it)
The `Layout/AlignParameters` cop has been renamed to
`Layout/ParameterAlignment`.
(obsolete configuration found in
/Users/michaelstone/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/gnar-style-0.8.0/rubocop/rubocop.yml,
please update it)
The `Layout/IndentFirstArrayElement` cop has been renamed to
`Layout/FirstArrayElementIndentation`.
(obsolete configuration found in
/Users/michaelstone/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/gnar-style-0.8.0/rubocop/rubocop.yml,
please update it)
```

This commit changes the cop names to fix those errors.