### PR TITLE
Removes "useless variable" cop from spec files

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -12,6 +12,10 @@ Layout/FirstArrayElementIndentation:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+Lint/UselessAssignment:
+  Exclude:
+    - "spec/**/*"
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'


### PR DESCRIPTION
Sometimes it's nice to assign a variable to setup data in a spec even if we're not referencing it again.