### PR TITLE
Remove class length cop from ActiveRecord models

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -16,6 +16,10 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'app/models/**/*'
+
 Metrics/LineLength:
   Max: 100
   Severity: refactor


### PR DESCRIPTION
They're always very long. Whaddya gonna do.