### PR TITLE
Rename line length cop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,61 @@
+PATH
+  remote: .
+  specs:
+    gnar-style (0.9.0)
+      rubocop (~> 0.78)
+      rubocop-performance
+      rubocop-rails (~> 2.2.0)
+      thor
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    parallel (1.19.1)
+    parser (2.7.0.1)
+      ast (~> 2.4.0)
+    rack (2.0.8)
+    rainbow (3.0.0)
+    rake (10.5.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.2)
+    rubocop (0.78.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-performance (1.5.2)
+      rubocop (>= 0.71.0)
+    rubocop-rails (2.2.1)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    ruby-progressbar (1.10.1)
+    thor (1.0.1)
+    unicode-display_width (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.14)
+  gnar-style!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   1.14.6

--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.77"
+  spec.add_dependency "rubocop", "~> 0.78"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails", "~> 2.2.0"
   spec.add_dependency "thor"

--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -16,7 +16,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
   Severity: refactor
 


### PR DESCRIPTION
Rename `Metrics/LineLength` `Layout/LineLength` and update the GemSpec.

I ran into this issue when updating the dependencies of a project that uses `gnar-style`. It turns out that RuboCop [0.78](https://github.com/rubocop-hq/rubocop/releases/tag/v0.78.0) moved the `LineLength` cop from `Metrics` to `Layout`.

---

I also added a commit that checks in `Gemfile.lock`.

Since version 1.16, Bundler [recommends](https://bundler.io/blog/2018/01/17/making-gem-development-a-little-better.html) checking in the file. Checking in the file also makes it easier for a new contributor who happens to have Bundler 2.0 installed. Without a `Gemfile.lock`, running `bundle install` with Bundler 2.0 doesn't work and spits out the confusing error `Bundler could not find compatible versions for gem "bundler"`. With `Gemfile.lock`, Bundler [automatically](https://bundler.io/guides/bundler_2_upgrade.html#version-autoswitch) chooses the right version.