### PR TITLE
Update to Bundler 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,15 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - gnar-style-
 
+      # update bundler
+      - run:
+          name: Update bundler
+          command: gem uninstall bundler && gem install bundler
+
       # Bundle install dependencies
       - run:
           name: install dependencies
-          command: bundle install --path vendor/bundle
+          command: bundle config set path 'vendor/bundle' && bundle install
 
       # Store bundle cache
       - save_cache:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     diff-lcs (1.3)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.0.1)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
     rack (2.0.8)
     rainbow (3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
-    rack (2.0.8)
+    rack (2.1.1)
     rainbow (3.0.0)
     rake (10.5.0)
     rspec (3.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,4 +58,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.3
+   2.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     thor (1.0.1)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)


### PR DESCRIPTION
Following the [upgrade docs](https://bundler.io/guides/bundler_2_upgrade.html)
this comes from running `bundle update --bundler`.

This also installs the latest bundler version on circle CI.

Our CI current images do not have a bundler 2.x version installed on
them. As such, this adds a step to remove the current version of
bundler and install the latest version.

As part of that, the install dependencies instructions also changed as
part of using `bundler 2`. If you run `bundle install --path vendor/bundle`,
you'll receive the following deprecation warning:

> [DEPRECATED] The --path flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set path 'vendor/bundle', and stop using this flag