### PR TITLE
Enable pending cops from 0.80 update

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -62,3 +62,16 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
+
+# ---------------------------------------------------
+# PENDING COPS: REMOVE AFTER INCORPORATED INTO RUBOCOP
+# ---------------------------------------------------
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true


### PR DESCRIPTION
This change resolves issue #48 by enabling the following cops:

Style/HashEachMethods

```
bad:
hash.keys.each { |k| p k }
hash.values.each { |v| p v }

good:
hash.each_key { |k| p k }
hash.each_value { |v| p v }
```

Style/HashTransformKeys

```
bad:
{a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[foo(k)] = v }
{a: 1, b: 2}.map { |k, v| [k.to_s, v] }

good:
{a: 1, b: 2}.transform_keys { |k| foo(k) }
{a: 1, b: 2}.transform_keys { |k| k.to_s }
```

Style/HashTransformValues

```
bad:
{a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
{a: 1, b: 2}.map { |k, v| [k, v * v] }

good:
{a: 1, b: 2}.transform_values { |v| foo(v) }
{a: 1, b: 2}.transform_values { |v| v * v }
```

Until a decision is rendered on these cops, we'll see this warning message every time we run Rubocop on version 0.8.0

![Terminal_—_tmux_attach-session_-t_dpu_—_293×70](https://user-images.githubusercontent.com/8248100/76416453-83170680-6371-11ea-8695-fa2f44065b28.png)