### PR TITLE
Bind rubocop to => 0.9.0 to align with `pronto-rubocop`. 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     gnar-style (0.13.0)
-      rubocop (>= 1.0.0, < 2.0)
+      rubocop (>= 0.9.0, < 1.0)
       rubocop-performance
       rubocop-rails (~> 2.2.0)
       thor
@@ -10,15 +10,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
+    ast (2.4.2)
     diff-lcs (1.3)
-    parallel (1.20.0)
-    parser (2.7.2.0)
+    parallel (1.20.1)
+    parser (3.0.0.0)
       ast (~> 2.4.1)
     rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.1)
-    regexp_parser (1.8.2)
+    regexp_parser (2.0.3)
     rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -33,25 +33,25 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (1.3.1)
+    rubocop (0.93.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8)
       rexml
-      rubocop-ast (>= 1.1.1)
+      rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.1.1)
+    rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
-    rubocop-performance (1.9.0)
+    rubocop-performance (1.9.2)
       rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     rubocop-rails (2.2.1)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    ruby-progressbar (1.10.1)
-    thor (1.0.1)
+    ruby-progressbar (1.11.0)
+    thor (1.1.0)
     unicode-display_width (1.7.0)
 
 PLATFORMS
@@ -64,4 +64,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.4

--- a/gnar-style.gemspec
+++ b/gnar-style.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 1.0.0", "< 2.0"
+  spec.add_dependency "rubocop", ">= 0.9.0", "< 1.0"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails", "~> 2.2.0"
   spec.add_dependency "thor"


### PR DESCRIPTION
This PR bumps down the required version of Rubocop from `1.0.0` to `0.9.0` to satisfy align itself with the restrictions of `pronto-rubocop` as leveraged in gnarails. 

We encountered an issue where `rails new` was causing the dependency resolver to hang. Further investigations showed the version misalignment between `rubocop` as required in `gnar-style` and the rubocop restrictions required by `pronto-rubocop` [(specifically, `< 1.0`)](https://github.com/prontolabs/pronto-brakeman/blob/master/pronto-brakeman.gemspec). 

There are two open PR's in `pronto-rubocop` to bring this up to requiring 1.0.0, ([this one](https://github.com/prontolabs/pronto-rubocop/pull/60) is furthest along) and we should be able to bump this back as soon as it is merged in. Happy to bump the version number here as well if we want to do that! 