### PR TITLE
Minor fixes for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Gnar shared style configurations.
 Add this line to your application's Gemfile:
 
 ```ruby
-group :development, :test
+group :development, :test do
   gem 'gnar-style'
 end
 ```
@@ -94,7 +94,7 @@ Consider the following:
 # In gnar-style/default.yml
 Metrics/BlockLength:
   Exclude:
-    - 'spec/**/*'
+    - "spec/**/*"
 ```
 
 ```yaml


### PR DESCRIPTION
I was installing this gem for a new project and I noticed two small issues in the README:

* The `do` is missing in the setup section.
* One of the YAML snippets uses single quotes while the rest of them use double quotes.
